### PR TITLE
Simplify installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,6 @@ install `omxr` directly from GitHub.
 devtools::install_github("gregmacfarlane/omxr")
 library(omxr)
 ```
-    
-Note that `omxr` functions import the `rhdf5` v2.5.1+ package from
-[Bioconductor](http://bioconductor.org/packages/release/bioc/html/rhdf5.html),
-which is also not on CRAN. If you do not already have this library installed, run 
-the following on your machine once,
-
-```r
-source("http://bioconductor.org/biocLite.R")
-biocLite("rhdf5")
-```
 
 Examples for using the package functions are in the package vignette,
 ```r
@@ -34,8 +24,6 @@ Beginners
 Run the following on your machine if you are new to R,
 
 ```r
-source("http://bioconductor.org/biocLite.R")
-biocLite("rhdf5")
 install.packages("devtools")
 devtools::install_github("gregmacfarlane/omxr")
 library(omxr)


### PR DESCRIPTION
https://github.com/r-lib/devtools/issues/700#issuecomment-235127291
Including `biocViews:` in your DESCRIPTION file is all that's needed these days to install the Bioconductor dependencies. You don't actually even need anything after it. I just confirmed by installing `omxr` using `devtools::install_github()`, and it automatically ran through and installed `rhdf5`.

In addition, it appears that this is CRAN-ready. ([stackoverflow](https://bioinformatics.stackexchange.com/questions/3365/r-package-development-how-does-one-automatically-install-bioconductor-packages/3375)). One of the answers there also links to [this DESCRIPTION file](https://github.com/HannahVMeyer/PhenotypeSimulator/blob/6ba850c74d641278f75e30c4750cb2d545522689/DESCRIPTION#L28), which shows a CRAN package with that included. This may resolve gregmacfarlane/omxr#7.

This PR just removes the extra installation steps from the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gregmacfarlane/omxr/9)
<!-- Reviewable:end -->
